### PR TITLE
Feature #13 export component profiles in json format

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -5,10 +5,6 @@ export interface VueScannerOption {
 	ignore?: string[];
 	verbose?: boolean;
 	debug?: boolean;
-	url?: string;
-	local?: number;
-	workspace?: string;
-	token?: string;
 }
 
 export interface PackageGroup {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,11 @@
+export type OutputFormat = "json" | "stdout";
 export interface VueScannerOption {
 	appDir: string;
+	output?: OutputFormat;
 	ignore?: string[];
 	verbose?: boolean;
 	debug?: boolean;
 	url?: string;
-	output?: string;
 	local?: number;
 	workspace?: string;
 	token?: string;

--- a/src/utils/file.utils.ts
+++ b/src/utils/file.utils.ts
@@ -69,11 +69,11 @@ export async function getSupportedFiles(
 
 export const writeResultToFile = (
 	relativeFilePath: string,
-	data: any
+	data: string
 ): Promise<string> => {
 	const filePath = resolve(relativeFilePath);
 	return new Promise<string>((resolve, reject) => {
-		writeFile(filePath, JSON.stringify(data), (err) => {
+		writeFile(filePath, data, (err) => {
 			if (err) {
 				logger.log("Error saving file:", err);
 				reject(err);

--- a/src/vue-scanner.ts
+++ b/src/vue-scanner.ts
@@ -964,8 +964,17 @@ export class VueScanner implements Scanner {
 				this.componentProfiles
 			);
 		}
-		if (this.option?.output === "json") {
-			await this.writeComponentProfilesToJson(this.componentProfiles);
+		if (this.option?.output) {
+			switch (this.option.output) {
+				case "json":
+					await this.writeComponentProfilesToJson(this.componentProfiles);
+					break;
+				case "stdout":
+					console.log(this.componentProfiles);
+					break;
+				default:
+					break;
+			}
 		}
 		return this.componentProfiles;
 	}

--- a/src/vue-scanner.ts
+++ b/src/vue-scanner.ts
@@ -777,7 +777,7 @@ export class VueScanner implements Scanner {
 	}
 
 	/**
- 	* Writes an array of component profiles to a JSON file within the specified app directory.
+ 	* Write an array of component profiles to a JSON file within the specified app directory.
 
  	* @param componentProfiles An array of component profiles to be written to the file.
  	* @returns The path of the file where the component profiles were written.

--- a/tests/component-profiles.spec.ts
+++ b/tests/component-profiles.spec.ts
@@ -1,0 +1,48 @@
+import { existsSync, readFileSync } from "fs";
+import VueScanner from "../src";
+import { ComponentProfile } from "../src/types";
+
+const componentProfiles = require("./example/components.json");
+
+function isComponentProfile(obj: any): obj is ComponentProfile {
+	return typeof obj === "object" &&
+		"name" in obj &&
+		"type" in obj &&
+		typeof obj.name === "string" &&
+		obj.type
+		? typeof obj.type === "string"
+		: obj.type === null;
+}
+describe("The type of result must be ComponentProfile[]", () => {
+	it("should be an array of object", async () => {
+		console.log(typeof componentProfiles);
+		expect(componentProfiles).toBeInstanceOf(Object);
+		expect(Array.isArray(componentProfiles)).toBeTruthy();
+	});
+	componentProfiles.forEach((componentProfile) => {
+		test(`typeof componentProfile must be ComponentProfile `, () => {
+			expect(isComponentProfile(componentProfile)).toBeTruthy();
+		});
+	});
+});
+
+describe("The output must be written as json format", () => {
+	const directory = `${__dirname}/example`.replace(/\\/g, "/");
+	const appDir = `${directory}/.test`;
+	const vueScanner = new VueScanner(directory, {
+		appDir,
+	});
+	it("should return an existing json path", async () => {
+		await vueScanner
+			.writeComponentProfilesToJson(componentProfiles)
+			.then((pathOfFile) => {
+				expect(existsSync(pathOfFile)).toBeTruthy();
+				const rawJson = readFileSync(pathOfFile, "utf8");
+				expect(JSON.parse(rawJson).length).toBe(componentProfiles.length);
+			})
+			.finally(() => {
+				vueScanner.removeAppDir();
+				expect(existsSync(appDir)).toBeFalsy();
+			});
+	});
+});

--- a/tests/example/components.json
+++ b/tests/example/components.json
@@ -1,0 +1,329 @@
+[
+  {
+    "name": "custom-comp",
+    "type": "internal",
+    "total": 2,
+    "source": {
+      "path": "/example-js/CustomComp.vue",
+      "property": {
+        "dataLastModified": "",
+        "lastModified": "",
+        "created": "",
+        "createdBy": "",
+        "updatedBy": ""
+      }
+    },
+    "usageLocations": [
+      {
+        "name": "custom-comp",
+        "source": "",
+        "destination": "/example-vue/AVueComposition.vue",
+        "rows": [
+          6
+        ],
+        "fileInfo": {
+          "path": "/example-js/CustomComp.vue",
+          "property": {
+            "dataLastModified": "",
+            "lastModified": "",
+            "created": "",
+            "createdBy": "",
+            "updatedBy": ""
+          }
+        }
+      },
+      {
+        "name": "custom-comp",
+        "source": "/example-js/CustomComp.vue",
+        "destination": "/example-js/AVueOption.vue",
+        "rows": [
+          3
+        ],
+        "fileInfo": {
+          "path": "/Users/kittisak/REPO/berryjam/berryjam/tests/example/example-js/CustomComp.vue",
+          "property": {
+            "dataLastModified": "",
+            "lastModified": "",
+            "created": "",
+            "createdBy": "",
+            "updatedBy": ""
+          }
+        }
+      }
+    ],
+    "children": {
+      "total": 0,
+      "tags": [],
+      "source": "/example-js/CustomComp.vue"
+    }
+  },
+  {
+    "name": "AvuOption",
+    "type": null,
+    "total": 2,
+    "source": {
+      "path": "",
+      "property": {
+        "dataLastModified": "",
+        "lastModified": "",
+        "created": "",
+        "createdBy": "",
+        "updatedBy": ""
+      }
+    },
+    "usageLocations": [
+      {
+        "name": "AvuOption",
+        "source": "",
+        "destination": "/example-js/CJsOption.js",
+        "rows": [
+          4
+        ],
+        "fileInfo": {
+          "path": "",
+          "property": {
+            "dataLastModified": "",
+            "lastModified": "",
+            "created": "",
+            "createdBy": "",
+            "updatedBy": ""
+          }
+        }
+      },
+      {
+        "name": "AvuOption",
+        "source": "",
+        "destination": "/example-js/AJsOption.js",
+        "rows": [
+          4
+        ],
+        "fileInfo": {
+          "path": "",
+          "property": {
+            "dataLastModified": "",
+            "lastModified": "",
+            "created": "",
+            "createdBy": "",
+            "updatedBy": ""
+          }
+        }
+      }
+    ]
+  },
+  {
+    "name": "router-link",
+    "type": null,
+    "total": 2,
+    "source": {
+      "path": "",
+      "property": {
+        "dataLastModified": "",
+        "lastModified": "",
+        "created": "",
+        "createdBy": "",
+        "updatedBy": ""
+      }
+    },
+    "usageLocations": [
+      {
+        "name": "router-link",
+        "source": "",
+        "destination": "/example-scan-project/src/App.vue",
+        "rows": [
+          3,
+          4
+        ],
+        "fileInfo": {
+          "path": "",
+          "property": {
+            "dataLastModified": "",
+            "lastModified": "",
+            "created": "",
+            "createdBy": "",
+            "updatedBy": ""
+          }
+        }
+      }
+    ]
+  },
+  {
+    "name": "router-view",
+    "type": null,
+    "total": 1,
+    "source": {
+      "path": "",
+      "property": {
+        "dataLastModified": "",
+        "lastModified": "",
+        "created": "",
+        "createdBy": "",
+        "updatedBy": ""
+      }
+    },
+    "usageLocations": [
+      {
+        "name": "router-view",
+        "source": "",
+        "destination": "/example-scan-project/src/App.vue",
+        "rows": [
+          6
+        ],
+        "fileInfo": {
+          "path": "",
+          "property": {
+            "dataLastModified": "",
+            "lastModified": "",
+            "created": "",
+            "createdBy": "",
+            "updatedBy": ""
+          }
+        }
+      }
+    ]
+  },
+  {
+    "name": "Home",
+    "type": "internal",
+    "total": 1,
+    "source": {
+      "path": "/example-scan-project/src/views/Home.tsx",
+      "property": {
+        "dataLastModified": "",
+        "lastModified": "",
+        "created": "",
+        "createdBy": "",
+        "updatedBy": ""
+      }
+    },
+    "usageLocations": [
+      {
+        "name": "Home",
+        "source": "",
+        "destination": "/example-scan-project/src/App.vue",
+        "rows": [
+          7
+        ],
+        "fileInfo": {
+          "path": "/example-scan-project/src/views/Home.tsx",
+          "property": {
+            "dataLastModified": "",
+            "lastModified": "",
+            "created": "",
+            "createdBy": "",
+            "updatedBy": ""
+          }
+        }
+      }
+    ],
+    "children": {
+      "total": 2,
+      "tags": [
+        "ExampleOne",
+        "ExampleTwo"
+      ],
+      "source": "/example-scan-project/src/views/Home.tsx"
+    }
+  },
+  {
+    "name": "ExampleOne",
+    "type": "internal",
+    "total": 1,
+    "source": {
+      "path": "/example-scan-project/src/components/ExampleOne.tsx",
+      "property": {
+        "dataLastModified": "",
+        "lastModified": "",
+        "created": "",
+        "createdBy": "",
+        "updatedBy": ""
+      }
+    },
+    "usageLocations": [
+      {
+        "name": "ExampleOne",
+        "source": "/example-scan-project/src/components/ExampleOne.tsx",
+        "destination": "/example-scan-project/src/views/Home.tsx",
+        "rows": [
+          16
+        ],
+        "fileInfo": {
+          "path": "/example-scan-project/src/components/ExampleOne.tsx",
+          "property": {
+            "dataLastModified": "",
+            "lastModified": "",
+            "created": "",
+            "createdBy": "",
+            "updatedBy": ""
+          }
+        }
+      }
+    ],
+    "children": {
+      "total": 0,
+      "tags": [],
+      "source": "/example-scan-project/src/components/ExampleOne.tsx"
+    },
+    "properties": [
+      {
+        "name": "msg",
+        "type": "string"
+      },
+      {
+        "name": "obj",
+        "type": "object"
+      },
+      {
+        "name": "items",
+        "type": "array"
+      },
+      {
+        "name": "onClick",
+        "type": "Function"
+      },
+      {
+        "name": "slotWrapItem",
+        "type": "Function"
+      }
+    ]
+  },
+  {
+    "name": "ExampleTwo",
+    "type": "internal",
+    "total": 1,
+    "source": {
+      "path": "/example-scan-project/src/components/ExampleTwo.tsx",
+      "property": {
+        "dataLastModified": "",
+        "lastModified": "",
+        "created": "",
+        "createdBy": "",
+        "updatedBy": ""
+      }
+    },
+    "usageLocations": [
+      {
+        "name": "ExampleTwo",
+        "source": "/example-scan-project/src/components/ExampleTwo.tsx",
+        "destination": "/example-scan-project/src/views/Home.tsx",
+        "rows": [
+          33
+        ],
+        "fileInfo": {
+          "path": "/example-scan-project/src/components/ExampleTwo.tsx",
+          "property": {
+            "dataLastModified": "",
+            "lastModified": "",
+            "created": "",
+            "createdBy": "",
+            "updatedBy": ""
+          }
+        }
+      }
+    ],
+    "children": {
+      "total": 0,
+      "tags": [],
+      "source": "/example-scan-project/src/components/ExampleTwo.tsx"
+    }
+  }
+]


### PR DESCRIPTION
**Description:**

This pull request addresses Issue #13 and introduces a new feature to export component profiles in JSON format. This feature enhances our application by allowing users to export their component profiles for various purposes.

## Changes Made

- Modified the `writeResultToFile` function in `file.utils.ts` to accept data as a string parameter, ensuring compatibility with the new export format.
- Updated the `VueScannerOption` interface to use the `OutputFormat` type for the `output` property. This change provides clarity and consistency by specifying that the `output` property can be either 'json' or 'stdout'.
- Introduced a new `writeComponentProfilesToJson` method in the `VueScanner` class to facilitate the export of component profiles in JSON format. This method efficiently handles the JSON export process.
- Set the `output` option in `VueScanner` to default to 'json'. This default ensures that component profiles are exported in JSON format by default, simplifying user interactions.
- Implemented unit tests to ensure the correctness of the export feature.

These changes collectively enhance our application by providing a streamlined and robust component profile export feature, with JSON as the default export format.

## Screenshots 
- `writeComponentProfilesToJson`
https://github.com/logicspark/berryjam/blob/fd4783142e3d45f79f9fc7f9ec452e73bf749840/src/vue-scanner.ts#L779-L787
- new test cases
`tests/component-profiles.spec.ts`

## Checklist

- [x] Created unit tests for the new feature.
- [x] Ensured all existing tests pass.
- [x] Verified the feature works as expected.
- [x] Followed the coding style and best practices.
- [ ] Updated the documentation.

## Related Issues

Closes #13 
