### PR TITLE
Feat/18 identify unused components

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   </a>
 </div>
 
-<h1 align="center">UI Components Anaylzer for Vue 3 & Nuxt</h1>
+<h1 align="center">UI Components Analyzer for Vue 3 & Nuxt</h1>
 
 <div align="center">
   Scan your Vue.js codebase for component visibility and actionable insights.
@@ -116,13 +116,43 @@ async function whatEverFunction() {
   const result = await vueScanner.scan();
 }
 
-
 ```
+_Note: For a **Nuxt** project, please ensure that you have a `.nuxt` folder before scanning._
+
+<br/>
+
+The `VueScanner` function takes two parameters as follow: 
+- The first parameter is the path of the project to be scanned.
+- The second is an option object that utilizes the `VueScannerOption` interface.
+
+Here is the detailed description of each available option within the `VueScannerOption` interface:
+
+### VueScannerOption Interface
+
+| Property   | Type                     | Description                                                         |
+|------------|--------------------------|---------------------------------------------------------------------|
+| `appDir`   | `string`                 | The path of the project directory to be scanned.                    |
+| `output`   | `OutputFormat` (optional)| The desired output format of the scanned result. (JSON by default)  |
+| `ignore`   | `string[]` (optional)    | An array of file names or directory names to exclude from scanning. |
+| `verbose`  | `boolean` (optional)     | Enable verbose mode for more detailed scanning information.         |
+| `debug`    | `boolean` (optional)     | Operate the scanner in debug mode, providing debugging information. |
+
+### OutputFormat Type
+
+The `OutputFormat` type represents available output formats.
+
+| Type       | Description                                                                                         |
+|------------|-----------------------------------------------------------------------------------------------------|
+| `"json"`   | Output the scanned result in JSON format and saved as 'component-profiles.json' within the 'appDir'.|
+| `"stdout"` | Display the scanned result directly in the console (stdout).                                        |
+
+These options and types offer flexibility and customization when using the `VueScanner` function to analyze Vue.js projects.
+
 For more details on `VueScanner` class, please check out [below](#VueScanner-Overview).
 
 ### Output
 
-By calling `scan` method, it will scan for Vue components and return `ComponentProfile[]`. If you `console.log` the output, here is an example of how it may look. For demonstration purposes, we have scanned an open-source project called [Koel](https://github.com/koel/koel).
+By calling the `scan` method, it will scan for Vue components and return `ComponentProfile[]`. Here is an example of how it may look. For demonstration purposes, we have scanned an open-source project called [Koel](https://github.com/koel/koel).
 
 <details open>
   <summary>Sample Result</summary>

--- a/documentation/welcome.md
+++ b/documentation/welcome.md
@@ -15,7 +15,11 @@ Berryjam contains 2 classes:
 
 ### VueScanner Class
 
-After importing the class, the `scan(path, option)` constructor may be called to instantiate the class
+After importing the class, you can instantiate it using the class constructor which requires two parameters: 
+- The first parameter is the path of the project to be scanned, and
+- The second is an option object that utilizes the `VueScannerOption` interface.
+
+After instantiation, you can use the `scan` method to start scanning your project.
 
 ```js
 const vueScanner = new VueScanner(path, option);
@@ -27,6 +31,29 @@ The constructor will perform the following:
 - Validate if the provided path exists
 - Validate if the package.json exists at the root of the provided path
 - Create a root directory with options to install Vue Compiler and Babel libraries
+
+For clearer understanding of each available option within the `VueScannerOption` interface, here is the detailed description:
+
+### VueScannerOption Interface
+
+| Property   | Type                     | Description                                                         |
+|------------|--------------------------|---------------------------------------------------------------------|
+| `appDir`   | `string`                 | The path of the project directory to be scanned.                    |
+| `output`   | `OutputFormat` (optional)| The desired output format of the scanned result. (JSON by default)  |
+| `ignore`   | `string[]` (optional)    | An array of file names or directory names to exclude from scanning. |
+| `verbose`  | `boolean` (optional)     | Enable verbose mode for more detailed scanning information.         |
+| `debug`    | `boolean` (optional)     | Operate the scanner in debug mode, providing debugging information. |
+
+### OutputFormat Type
+
+The `OutputFormat` type represents available output formats.
+
+| Type       | Description                                                                                         |
+|------------|-----------------------------------------------------------------------------------------------------|
+| `"json"`   | Output the scanned result in JSON format and saved as 'component-profiles.json' within the 'appDir'.|
+| `"stdout"` | Display the scanned result directly in the console (stdout).                                        |
+
+These options and types offer flexibility and customization when using the `VueScanner` function to analyze Vue.js projects.
 
 There are 5 steps to scan Vue components with `VueScanner`. These steps are as follow:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "berryjam",
-	"version": "0.1.0-alpha.53",
+	"version": "0.1.0-alpha.54",
 	"description": "Berryjam helps you analyze and optimize your Vue.js component code with ease. Save time communicating and effort in development to create better, more efficient code.",
 	"private": false,
 	"exports": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,7 +35,9 @@ export interface ImportStatement {
 	importedNames: string[];
 	source: string;
 	importSourceType: ComponentSourceType;
+	destination?: string;
 	sourcePath?: string;
+	dynamic?: boolean;
 }
 
 export interface VueProperty {

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,13 +31,18 @@ export interface ChildComponentTag {
 
 export type ComponentSourceType = "internal" | "external" | null;
 
+export type ImportStatementUsage = {
+	lines: Record<string, number[]>;
+	dynamic: boolean;
+	importPath: string;
+};
 export interface ImportStatement {
 	importedNames: string[];
 	source: string;
+	destination: string;
 	importSourceType: ComponentSourceType;
-	destination?: string;
 	sourcePath?: string;
-	dynamic?: boolean;
+	usage?: ImportStatementUsage;
 }
 
 export interface VueProperty {
@@ -61,7 +66,7 @@ export interface FileProperty {
 }
 export interface FileInfo {
 	path: string;
-	property: FileProperty;
+	property: FileProperty | null;
 }
 
 export interface VueComponent {

--- a/src/utils/compiler.ts
+++ b/src/utils/compiler.ts
@@ -80,7 +80,7 @@ export function parseVue(
 
 		const scriptContent = `${script?.content || scriptSetup?.content || ""}`;
 		importStatements = traverseImports(
-			currentDir,
+			filePath,
 			scriptContent,
 			babelParse,
 			script?.lang || scriptSetup?.lang
@@ -223,12 +223,12 @@ export function parseTypescript(
 	) => BabelParser.ParseResult<any>
 ): ParsedCodeResult {
 	let componentTags: TraversedTag[] = [];
-	const { fileContent, currentDir } = getFileInfo(filePath);
+	const { fileContent } = getFileInfo(filePath);
 	let importStatements: ImportStatement[] | null = null;
 	let properties: VueProperty[] = [];
 	try {
 		importStatements = traverseImports(
-			currentDir,
+			filePath,
 			fileContent,
 			babelParse,
 			extension

--- a/src/utils/compiler.ts
+++ b/src/utils/compiler.ts
@@ -296,6 +296,7 @@ export function parseComponentsDeclaration(
 											? resolve(currentDir, importFrom)
 											: importFrom,
 										importSourceType: isRelative ? "internal" : "external",
+										destination: filePath,
 									} as ImportStatement;
 									componentDeclarations.push(currentImportLine);
 								}

--- a/src/utils/text.utils.ts
+++ b/src/utils/text.utils.ts
@@ -1,11 +1,22 @@
-const removeDashesAndConvertToUpperCase = (text: string) => {
-	return text.replace(/-/, "").toUpperCase();
-};
+/**
+ * Converts a kebab-case string to camelCase.
+ * For example, "my-example-string" becomes "myExampleString".
+ * @param input The kebab-case string to convert.
+ * @returns The converted CamelCase string.
+ */
+export function kebabCaseToCamelCase(input: string) {
+	const converted = input.replace(/-([a-z])/g, function (match, letter) {
+		return letter.toUpperCase();
+	});
+	return converted.charAt(0).toUpperCase() + converted.slice(1);
+}
 
-export const kebabCaseToCamelCase = (text: string) => {
-	return text.replace(/-\w/g, removeDashesAndConvertToUpperCase);
-};
-
-export const kebabCaseToPascalCase = (text: string) => {
-	return text.replace(/(^\w|-\w)/g, removeDashesAndConvertToUpperCase);
-};
+/**
+ * Converts a kebab-case string to camelCase.
+ * For example, "my-example-string" becomes "myExampleString".
+ * @param input The kebab-case string to convert.
+ * @returns The converted camelCase string.
+ */
+export function camelCaseToKebabCase(input: string) {
+	return input.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase();
+}

--- a/src/utils/text.utils.ts
+++ b/src/utils/text.utils.ts
@@ -1,10 +1,10 @@
 /**
- * Converts a kebab-case string to camelCase.
+ * Converts a kebab-case string to PascalCase.
  * For example, "my-example-string" becomes "myExampleString".
  * @param input The kebab-case string to convert.
- * @returns The converted CamelCase string.
+ * @returns The converted PascalCase string.
  */
-export function kebabCaseToCamelCase(input: string) {
+export function kebabCaseToPascalCase(input: string) {
 	const converted = input.replace(/-([a-z])/g, function (match, letter) {
 		return letter.toUpperCase();
 	});

--- a/src/utils/text.utils.ts
+++ b/src/utils/text.utils.ts
@@ -12,11 +12,11 @@ export function kebabCaseToPascalCase(input: string) {
 }
 
 /**
- * Converts a kebab-case string to camelCase.
+ * Converts a kebab-case string to pascalCase.
  * For example, "my-example-string" becomes "myExampleString".
  * @param input The kebab-case string to convert.
- * @returns The converted camelCase string.
+ * @returns The converted pascalCase string.
  */
-export function camelCaseToKebabCase(input: string) {
+export function pascalCaseToKebabCase(input: string) {
 	return input.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase();
 }

--- a/src/vue-scanner.ts
+++ b/src/vue-scanner.ts
@@ -1,9 +1,9 @@
 import { resolve, join, dirname, extname, basename, parse } from "path";
 import { existsSync, readFileSync, mkdirSync, writeFileSync, rmSync } from "fs";
 import { homedir } from "os";
-import countBy from "lodash/countBy";
+
 import groupBy from "lodash/groupBy";
-import map from "lodash/map";
+
 import mapValues from "lodash/mapValues";
 import omit from "lodash/omit";
 import {
@@ -819,11 +819,11 @@ export class VueScanner implements Scanner {
 	}
 
 	/**
- 	* Write an array of component profiles to a JSON file within the specified app directory.
+	* Write an array of component profiles to a JSON file within the specified app directory.
 
- 	* @param componentProfiles An array of component profiles to be written to the file.
- 	* @returns The path of the file where the component profiles were written.
- 	*/
+	* @param componentProfiles An array of component profiles to be written to the file.
+	* @returns The path of the file where the component profiles were written.
+	*/
 	async writeComponentProfilesToJson(
 		componentProfiles: ComponentProfile[]
 	): Promise<string> {


### PR DESCRIPTION
## Description

This Pull Request addresses issue #18 and introduces a new feature to identify and manage unused components within our codebase. With this enhancement, we can proactively identify components that are no longer in use, helping us maintain a cleaner and more efficient codebase.

## Changes Made

- in `scan()` method of `VueScanner`, added a new logic to analyze and detect unused components.

## How to Test

To test this new feature, follow these steps:

1. Ensure you have the latest code from the `feat/18-identify-unused-components` branch.
2. Run the command `npm install` to update dependencies.
3. Start the application and navigate to various views.
4. Observe the output in the console or check the generated reports for unused components.

## Related Issues

- Closes #18

## Checklist

- [x] Tests pass successfully.
- [x] All code is properly formatted and adheres to our coding standards.
- [x] Code has been reviewed by at least one team member.

Please review and merge this PR at your earliest convenience. If there are any concerns or questions, feel free to comment, and I'll address them promptly.
