### PR TITLE
feat/41: Add Public Method in VueScanner for GitService Access

### DIFF
--- a/src/utils/git.services.ts
+++ b/src/utils/git.services.ts
@@ -264,7 +264,7 @@ export class GitService {
 	 * Scan git log of the project to retrieve relevant git history such as.
 	 * author, datetime and file changes to output as a JSON file.
 	 */
-	scan = () => {
+	scan = async () => {
 		const currentCommitHash = this.executeCommand(`git rev-parse HEAD`);
 
 		if (currentCommitHash) {
@@ -288,7 +288,7 @@ export class GitService {
 					}
 				}
 			}
-			writeGlobJson(
+			await writeGlobJson(
 				this.appDir,
 				JSON.stringify({ origin: this.getOrigin(), result }, null, 2),
 				this.jsonfile

--- a/src/vue-scanner.ts
+++ b/src/vue-scanner.ts
@@ -821,6 +821,15 @@ export class VueScanner implements Scanner {
 	}
 
 	/**
+	 * Scans the Git repository for components in the specified directory and
+	 * creates a `git-parsed-diff.json` file in the target directory.
+	 */
+	scanGit() {
+		logger.log("Start git scanning");
+		return new GitService(this.option.appDir, this.scanPath).scan();
+	}
+
+	/**
 	 * Scan the project directory for Vue components, analyzes their structure, and collects information.
 	 *
 	 * @returns A promise that resolves an array of component profiles.
@@ -1076,7 +1085,7 @@ export class VueScanner implements Scanner {
 		this.mapComponentProfileProps(filePathToProperties);
 		if (existsSync(join(this.scanPath, ".git"))) {
 			// Use Git Scan
-			new GitService(this.option.appDir, this.scanPath).scan();
+			await this.scanGit();
 		}
 
 		if (this.option?.output) {


### PR DESCRIPTION
### Overview
This PR resolves issue #41  by introducing a new public method in the `VueScanner` class. The newly added method, `scanGit`, allows easy access to GitService functionality, simplifying its use for external applications. This change streamlines the interaction with GitService and improves the overall accessibility of the VueScanner.

### Changes
Added the scanGit method to the VueScanner class. This method utilizes the GitService class to perform Git log scanning.

### Closing Notes
This PR successfully addresses issue #41  and enhances the VueScanner's capabilities.