### PR TITLE
feat(scan): Add function to find end of line of file

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,7 @@ export interface FileProperty {
 	updatedBy: string;
 	lastModified: string;
 	dataLastModified: string;
+	endOfLines?: number;
 	package?: { name: string; version: string }; // TODO: check this key later
 }
 export interface FileInfo {

--- a/src/utils/file.utils.ts
+++ b/src/utils/file.utils.ts
@@ -104,12 +104,7 @@ export const checkFileTypeExists = (
 };
 
 export const getEndOfLine = (fileContent: string) => {
-	let endOfLine = 0;
-	const numberOfLine = fileContent.split(/\r\n|\r|\n/).length;
-	if (numberOfLine) {
-		endOfLine = numberOfLine;
-	}
-	return endOfLine;
+	return fileContent.split(/\r\n|\r|\n/).length;
 };
 
 export const writeGlobJson = (

--- a/src/utils/file.utils.ts
+++ b/src/utils/file.utils.ts
@@ -102,3 +102,12 @@ export const checkFileTypeExists = (
 	}
 	return { exists: existsSync(filePath), filePath };
 };
+
+export const getEndOfLine = (fileContent: string) => {
+	let endOfLine = 0;
+	const numberOfLine = fileContent.split(/\r\n|\r|\n/).length;
+	if (numberOfLine) {
+		endOfLine = numberOfLine;
+	}
+	return endOfLine;
+};

--- a/src/vue-scanner.ts
+++ b/src/vue-scanner.ts
@@ -8,6 +8,8 @@ import {
 	getSupportedFiles,
 	transformStringToRegex,
 	writeResultToFile,
+	getEndOfLine,
+	getFileInfo,
 } from "./utils/file.utils";
 import { DEF_IGNORE_FILES, SUPPORT_EXT } from "./utils/constants";
 import type {
@@ -23,6 +25,7 @@ import type {
 	VueComponent,
 	OutputFormat,
 	ImportStatementUsage,
+	FileProperty,
 } from "./types";
 import { spawnSync } from "node:child_process";
 import {
@@ -515,7 +518,7 @@ export class VueScanner implements Scanner {
 							updatedBy: "",
 						},
 					},
-				};
+				} as VueComponent;
 				this.vueComponents.push(vueComponent);
 			}
 		});
@@ -689,7 +692,7 @@ export class VueScanner implements Scanner {
 					created: "",
 					createdBy: "",
 					updatedBy: "",
-				};
+				} as FileProperty;
 				ele.children = { total: 0, tags: [], source: "" };
 				if (importSourceType === "internal") {
 					children.forEach((child) => {
@@ -925,13 +928,20 @@ export class VueScanner implements Scanner {
 					// assume it is component, store all file into `componentFiles`
 					const name = parse(filePath).name;
 					componentFiles.push({ name, filePath });
+					const { fileContent } = getFileInfo(filePath);
+					const endOfLines = getEndOfLine(fileContent);
 					const vueComponent: VueComponent = {
 						name,
 						source: filePath,
 						destination: filePath,
 						rows: [],
 						deepestNested,
-						fileInfo: { path: "", property: null },
+						fileInfo: {
+							path: "",
+							property: {
+								endOfLines,
+							} as FileProperty,
+						},
 					};
 					this.vueComponents.push(vueComponent);
 				}

--- a/tests/component-size.spec.ts
+++ b/tests/component-size.spec.ts
@@ -1,0 +1,37 @@
+import { getEndOfLine, getFileInfo } from "../src/utils/file.utils";
+
+let directory: string;
+
+beforeEach(() => {
+	directory = `${__dirname}/example`.replace(/\\/g, "/");
+});
+
+describe("Parse .jsx file.The output must be the number of lines of the file", () => {
+	const endOfLineFileTest = 15;
+	it(`should be an number ${endOfLineFileTest}`, async () => {
+		const filePath = `${directory}/example-jsx/Example.jsx`;
+		const { fileContent } = getFileInfo(filePath);
+		const endOfLines = getEndOfLine(fileContent);
+		expect(endOfLines).toBe(endOfLineFileTest);
+	});
+});
+
+describe("Parse .vue file.The output must be the number of lines of the file", () => {
+	const endOfLineFileTest = 15;
+	it(`should be an number ${endOfLineFileTest}`, async () => {
+		const filePath = `${directory}/example-vue/AVueComposition.vue`;
+		const { fileContent } = getFileInfo(filePath);
+		const endOfLines = getEndOfLine(fileContent);
+		expect(endOfLines).toBe(endOfLineFileTest);
+	});
+});
+
+describe("Parse .ts file.The output must be the number of lines of the file", () => {
+	const endOfLineFileTest = 6;
+	it(`should be an number ${endOfLineFileTest}`, async () => {
+		const filePath = `${directory}/example-ts/ATsOption.ts`;
+		const { fileContent } = getFileInfo(filePath);
+		const endOfLines = getEndOfLine(fileContent);
+		expect(endOfLines).toBe(endOfLineFileTest);
+	});
+});


### PR DESCRIPTION
### Overview
This pull request addresses a feature request for the scan module. It introduces a new function that allows us to determine the end of a line within a file. The getEndOfLine function has been added to provide this capability. This can be useful for various scanning and parsing file, as it allows us to identify the end of a line

### Related Issue
- Solve #35 