### PR TITLE
fix(scan): endOfLines property does not appear

### DIFF
--- a/src/vue-scanner.ts
+++ b/src/vue-scanner.ts
@@ -692,6 +692,7 @@ export class VueScanner implements Scanner {
 					created: "",
 					createdBy: "",
 					updatedBy: "",
+					...componentSource.property,
 				} as FileProperty;
 				ele.children = { total: 0, tags: [], source: "" };
 				if (importSourceType === "internal") {


### PR DESCRIPTION
solve #46, This pull request addresses the issue related to the "endOfLines" property not appearing as expected in the scanner component. The issue has been identified and resolved in this change.