### PR TITLE
Fix Git Scan Error: Fatal Ambiguous Argument in `git diff`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
 	"prettier.configPath": ".prettierrc",
 	"prettier.requireConfig": true,
 	"editor.formatOnSave": true,
-	"prettier.htmlWhitespaceSensitivity": "strict"
+	"prettier.htmlWhitespaceSensitivity": "strict",
+	"cSpell.words": ["datetime"]
 }

--- a/src/utils/git.services.ts
+++ b/src/utils/git.services.ts
@@ -1,6 +1,5 @@
-import { ExecException, execSync } from "child_process";
+import { execSync } from "child_process";
 import { ParsedGitDiff } from "../interfaces/git.services.interfaces";
-import _ from "lodash";
 import { writeGlobJson } from "./file.utils";
 import { GitParser } from "./git.parser";
 
@@ -64,7 +63,13 @@ export class GitService {
 	 * @returns A string of information taken from git diff details.
 	 */
 	getDiffDetails(commitHash: string) {
-		return this.executeCommand(`git diff ${commitHash}~ ${commitHash}`);
+		const existParent = this.executeCommand(
+			`git rev-parse --quiet ${commitHash}^@`
+		);
+		if (!existParent) {
+			return null;
+		}
+		return this.executeCommand(`git diff --quiet ${commitHash}~ ${commitHash}`);
 	}
 
 	/**

--- a/src/utils/git.services.ts
+++ b/src/utils/git.services.ts
@@ -63,13 +63,11 @@ export class GitService {
 	 * @returns A string of information taken from git diff details.
 	 */
 	getDiffDetails(commitHash: string) {
-		const existParent = this.executeCommand(
-			`git rev-parse --quiet ${commitHash}^@`
-		);
+		const existParent = this.executeCommand(`git rev-parse ${commitHash}^@`);
 		if (!existParent) {
 			return null;
 		}
-		return this.executeCommand(`git diff --quiet ${commitHash}~ ${commitHash}`);
+		return this.executeCommand(`git diff ${commitHash}~ ${commitHash}`);
 	}
 
 	/**

--- a/tests/git-services.spec.ts
+++ b/tests/git-services.spec.ts
@@ -57,9 +57,16 @@ describe("Git recursively method", () => {
 		);
 		let received: any = null;
 		if (currentHash) {
-			received = gitService.getDiffDetails(currentHash);
+			const existParents = gitService.executeCommand(
+				`git rev-parse ${currentHash}^@`
+			);
+			if (existParents) {
+				received = gitService.getDiffDetails(currentHash);
+				expect(typeof received).toBe("string");
+			} else {
+				expect(received).toBe(null);
+			}
 		}
-		expect(typeof received).toBe("string");
 	});
 
 	it("should be a string", async () => {


### PR DESCRIPTION
### Overview
I identified that the error is caused by the `git diff` command when the commit hash lacks a parent hash. To address this issue, I've implemented a check to verify the presence of a parent hash before executing the git diff command. This change helps to prevent the error from occurring.

### Closing Issue
- resolve #45 