### PR TITLE
Fix bug in Git Scan: Enclose ${commitHash}^@ in double quotes

### DIFF
--- a/src/utils/git.services.ts
+++ b/src/utils/git.services.ts
@@ -63,7 +63,7 @@ export class GitService {
 	 * @returns A string of information taken from git diff details.
 	 */
 	getDiffDetails(commitHash: string) {
-		const existParent = this.executeCommand(`git rev-parse ${commitHash}^@`);
+		const existParent = this.executeCommand(`git rev-parse "${commitHash}^@"`);
 		if (!existParent) {
 			return null;
 		}

--- a/tests/git-services.spec.ts
+++ b/tests/git-services.spec.ts
@@ -58,7 +58,7 @@ describe("Git recursively method", () => {
 		let received: any = null;
 		if (currentHash) {
 			const existParents = gitService.executeCommand(
-				`git rev-parse ${currentHash}^@`
+				`git rev-parse "${currentHash}^@"`
 			);
 			if (existParents) {
 				received = gitService.getDiffDetails(currentHash);


### PR DESCRIPTION
### Overview
This change adds double quotes around `${commitHash}^@` in Git commands to ensure consistent behavior in Windows terminals, where the `^` notation might not be displayed correctly. The double quotes help handle spaces and special characters in the commit hash.

### Closing issue
- solve #50 