### PR TITLE
Refactor: change `ComponentProfile` 'total' property to 'usage'

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -84,12 +84,11 @@ export interface VueComponent {
 export interface ComponentProfile {
 	name: string;
 	type: ComponentSourceType;
-	total: number;
+	usage: number;
 	source: FileInfo & { package?: LibDependency };
 	deepestNested: number;
-	properties?: VueProperty[];
 	usageLocations?: VueComponent[];
-	groups?: any;
+	properties?: VueProperty[];
 	children?: { total: number; tags: string[]; source: string };
 }
 

--- a/src/utils/module.utils.ts
+++ b/src/utils/module.utils.ts
@@ -108,7 +108,6 @@ export const traverseImports = (
 						} as ImportStatementUsage);
 					} else {
 						//mean using the import statement
-						//if (filePath?.includes("router.ts")) {
 						const { name } = path.node.value;
 						const found = mappedImportList.find((ele) =>
 							ele.importedNames.includes(name)
@@ -122,7 +121,6 @@ export const traverseImports = (
 								importPath: found.source,
 							};
 						}
-						// }
 					}
 				}
 			},
@@ -222,12 +220,10 @@ export async function getCodeConfigCompilerOptionPaths(
 	for (const fPath of foundConfigFiles.filter(
 		(ele) => !ele.includes("/node_modules/")
 	)) {
-		// logger.debug({ fPath });
 		try {
 			const result = loadConfig(fPath);
 			const { resultType } = result;
 			if ("success" === resultType) {
-				// logger.debug({ result }, "[Func] getCodeConfigCompilerOptionPaths");
 				const { absoluteBaseUrl, paths, baseUrl } = result;
 				pathsResult = {
 					...pathsResult,

--- a/src/vue-scanner.ts
+++ b/src/vue-scanner.ts
@@ -1109,16 +1109,20 @@ export class VueScanner implements Scanner {
 				foundUsageLocations?.filter((ele) => ele.rows.length) ?? [];
 			// If there's a foundImportWithUsage, add it to the component's usageLocations
 			if (foundImportWithUsage) {
-				const tmpVueComponent = {
-					name: "",
-					source:
-						foundImportWithUsage.sourcePath ?? foundImportWithUsage.source,
-					destination: foundImportWithUsage.destination,
-					rows: foundImportWithUsage.usage!.lines[
-						foundImportWithUsage.destination
-					],
-				} as VueComponent;
-				arr[idx].usageLocations!.push(tmpVueComponent);
+				const { usage } = foundImportWithUsage;
+				if (usage?.lines) {
+					Object.keys(usage.lines).forEach((destPath) => {
+						const rows = usage.lines[destPath];
+						const tmpVueComponent = {
+							name: "",
+							source:
+								foundImportWithUsage.sourcePath ?? foundImportWithUsage.source,
+							destination: destPath,
+							rows,
+						} as VueComponent;
+						arr[idx].usageLocations!.push(tmpVueComponent);
+					});
+				}
 			}
 		});
 

--- a/tests/analyze-component-files.spec.ts
+++ b/tests/analyze-component-files.spec.ts
@@ -207,7 +207,7 @@ describe("Remove duplicate components", () => {
 		componentProfiles.push({
 			name: "Button",
 			type: "internal",
-			total: 0,
+			usage: 0,
 			deepestNested: 0,
 			source: {
 				path: "C:/projects/berryjam-cli/public/Components/Header.js",
@@ -221,7 +221,6 @@ describe("Remove duplicate components", () => {
 			},
 			properties: [],
 			usageLocations: [],
-			groups: [],
 			children: { total: 1, tags: ["Button"], source: "" },
 		});
 		// Push 2nd object
@@ -229,7 +228,7 @@ describe("Remove duplicate components", () => {
 			name: "Button",
 			type: "internal",
 			deepestNested: 0,
-			total: 0,
+			usage: 0,
 			source: {
 				path: "C:/projects/berryjam-cli/public/Components/Header.js",
 				property: {
@@ -242,7 +241,6 @@ describe("Remove duplicate components", () => {
 			},
 			properties: [],
 			usageLocations: [],
-			groups: [],
 			children: { total: 1, tags: ["Button"], source: "" },
 		});
 


### PR DESCRIPTION
### Overview

This PR addresses issue #52 , which involves changing the 'total' property in the ComponentProfile to 'usage'. The transformation of this property is crucial for improving clarity and relevancy of the VueScanner's functionality.

### Changes
1. In the scanner module, the reviseGroupedComponentSources function has been added to support the renaming of the 'total' property to 'usage'.
2. The 'usageLocation' module has been updated to ensure the correct preparation of usage location data.
3. Unused code lines have been removed from the `module.utils.ts` to maintain code cleanliness.

The modifications will provide more accurate information in the ComponentProfile and enhance the overall usability of the VueScanner.

### Closing Notes
- This change will help streamline the VueScanner's output and make it more meaningful for users, resolve #52 