### PR TITLE
Fix Bug/34: Resolve maximum call stack size exceeded issue in `getCodeConfigCompilerOptionPaths` during Quasar scan

### DIFF
--- a/src/utils/module.utils.ts
+++ b/src/utils/module.utils.ts
@@ -220,33 +220,29 @@ export async function getCodeConfigCompilerOptionPaths(
 	for (const fPath of foundConfigFiles.filter(
 		(ele) => !ele.includes("/node_modules/")
 	)) {
-		try {
-			const result = loadConfig(fPath);
-			const { resultType } = result;
-			if ("success" === resultType) {
-				const { absoluteBaseUrl, paths, baseUrl } = result;
-				pathsResult = {
-					...pathsResult,
-					...Object.entries(paths).reduce(
-						(obj, p) => {
-							const key = p[0],
-								value = p[1];
-							if (typeof value == "object") {
-								const newValue = value.map((ele: string) =>
-									join(`${absoluteBaseUrl}`, ele)
-								);
-								obj[key] = newValue;
-							} else {
-								obj[key] = value;
-							}
-							return obj;
-						},
-						{} as Record<string, string[]>
-					),
-				};
-			}
-		} catch (error) {
-			console.error(error, "[Func] getCodeConfigCompilerOptionPaths");
+		const result = loadConfig(fPath);
+		const { resultType } = result;
+		if ("success" === resultType) {
+			const { absoluteBaseUrl, paths } = result;
+			pathsResult = {
+				...pathsResult,
+				...Object.entries(paths).reduce(
+					(obj, p) => {
+						const key = p[0],
+							value = p[1];
+						if (typeof value == "object") {
+							const newValue = value.map((ele: string) =>
+								join(`${absoluteBaseUrl}`, ele)
+							);
+							obj[key] = newValue;
+						} else {
+							obj[key] = value;
+						}
+						return obj;
+					},
+					{} as Record<string, string[]>
+				),
+			};
 		}
 	}
 	return Object.keys(pathsResult)?.length ? pathsResult : null;

--- a/src/vue-scanner.ts
+++ b/src/vue-scanner.ts
@@ -349,7 +349,12 @@ export class VueScanner implements Scanner {
 	 * @returns A Promise that resolves to an object containing merged alias paths.
 	 */
 	async prepareAliasPaths(packageJsonPath: string, babelParser: BabelParser) {
-		let aliasPaths = await getCodeConfigCompilerOptionPaths(packageJsonPath);
+		let aliasPaths: Record<string, string[]> | null = null;
+		try {
+			aliasPaths = await getCodeConfigCompilerOptionPaths(packageJsonPath);
+		} catch (error) {
+			logger.log(error);
+		}
 		const vitePath = await getViteAliasPaths(
 			packageJsonPath,
 			babelParser.parse


### PR DESCRIPTION
### Overview
In this PR, I address the Bug #34 issue by refactoring the error handling. The error was traced back to the `loadConfig` function of the `tsconfig-paths` library. I removed the try-catch block from its original location and placed it in the `prepareAliasPaths` function. Additionally, I modified the handling to log the error only when the verbose option is parsed.

### Changes:
- Moved try-catch block from `getCodeConfigCompilerOptionPaths` to `prepareAliasPaths`
- Adjusted error logging to occur only when the verbose option is parsed

### Closing Notes
- resolve #34 